### PR TITLE
Checks for Underflow and Overflow

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
@@ -74,7 +74,12 @@ class CrashGenerationCleaner
     private static long batchSize( long pagesToClean, int threads )
     {
         // Batch size at most maxBatchSize, at least minBatchSize and trying to give each thread 100 batches each
-        return min( MAX_BATCH_SIZE, max( MIN_BATCH_SIZE, pagesToClean / (100 * threads) ) );
+        try {
+            int result = Math.multiplyExact(100 * threads);
+            return min(MAX_BATCH_SIZE, max(MIN_BATCH_SIZE, pagesToClean / result));
+        } catch (ArithmeticException e) {
+            return MIN_BATCH_SIZE;
+        }
     }
 
     // === Methods about the execution and threading ===


### PR DESCRIPTION
Fixes problem with arithmetic.

> Potential overflow in int multiplication before it is converted to long by use in a numeric context.

> https://lgtm.com/projects/g/neo4j/neo4j/snapshot/6942b12ecfeeb70635e1772178f66de2bde77f63/files/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java?sort=name&dir=ASC&mode=heatmap#x608199696a368709:1